### PR TITLE
hotfix : Fixed iOS Image Update Issue

### DIFF
--- a/Repository/authentication/ios/Runner/Info.plist
+++ b/Repository/authentication/ios/Runner/Info.plist
@@ -45,5 +45,9 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+    <string>We need access to your photo library to pick images.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>We need access to your camera to take photos.</string>
 </dict>
 </plist>


### PR DESCRIPTION
**Description**
This pull request addresses one specific issue in our project:

1. [LA-1014 FE: Fix iOS Photo Upload Issue](https://pm23.atlassian.net/browse/LA-1014)

**Changes Made**
I have made the following changes in the fix/mozammal/photo-update-issue-ios branch to resolve these issues:

- For LA-1014, I've fixed the issue related to the update profile photo upload that was crashing iOS when it was selected. To resovle this problem, I've added **gallery and camera permission** in  _ios/Runner/Info.plist._, which will ask the permission to the iOS user to use gallery and camera image.

**Context**
These changes are part of the fix process to maintain the stability and usability of our project. The pull request includes modifications that have been thoroughly tested and reviewed to ensure the quality of our software.

**Checklist**

- [x] The changes have been tested and reviewed.
- [x] The commits follow our commit message conventions.
- [x] The branch is up to date with the latest changes from the main branch.
- [x] The pull request title is clear and concise.

 **Reviewers**
 
[@dinurymomshad](https://github.com/dinurymomshad) please review the changes made to address LA-1014.

**Issue**

This pull request resolves issues [LA-1014](https://pm23.atlassian.net/browse/LA-1014) in our issue tracker.

**Additional Notes**

If you have any comments, questions, or suggestions regarding the changes made, or if other related issues need attention, please feel free to comment here.

Thank you for your review and feedback!
